### PR TITLE
CLDR-19254 fix cldr-identify.sh if your upstream is not named origin

### DIFF
--- a/cldr-identify.sh
+++ b/cldr-identify.sh
@@ -14,17 +14,20 @@ fi
 
 function explain_repo()
 {
-    git remote get-url origin | sed -E 's/git@github.com:|https:\/\/github.com\/|.git//g'
+    # set 'UPSTREAM_CLDR_JSON=upstream' etc. in local-config.sh to rename the remote
+    UPSTREAM_VAR=$(echo upstream-$1 | tr a-z- A-Z_)
+    UPSTREAM=${!UPSTREAM_VAR:-origin}
+    git remote get-url ${UPSTREAM} | sed -E 's/git@github.com:|https:\/\/github.com\/|.git//g'
     git describe --tags HEAD
 }
 
 echo "* cldr-json info"
 if [[ "$INDATA" == "generate" ]]
 then
-    echo "- DATA: " $(cd ${CLDR_DIR}; explain_repo) "(generated)"
-else 
-    echo "- DATA: " $(cd ${INDATA}; explain_repo)
+    echo "- DATA: " $(cd ${CLDR_DIR}; explain_repo cldr) "(generated)"
+else
+    echo "- DATA: " $(cd ${INDATA}; explain_repo cldr-staging)
 fi
-echo "- TOOL: " $(cd ${CLDR_DIR}; explain_repo)
-echo "- SCRIPT: " $(explain_repo)
+echo "- TOOL: " $(cd ${CLDR_DIR}; explain_repo cldr)
+echo "- SCRIPT: " $(explain_repo cldr-json)
 


### PR DESCRIPTION
in b08a82b582f1120d630d623f9e5073316741574d the `explain_repo()` bash function was used with more repos. However, not all of those have the same upstream name.

This allows you to configure the upstream name in local-config.sh

```properties
UPSTREAM_CLDR=upstream
UPSTREAM_CLDR_STAGING=upstream
UPSTREAM_CLDR_JSON=upstream
```